### PR TITLE
Update SSDL_font.h

### DIFF
--- a/external/SSDL/include/SSDL_font.h
+++ b/external/SSDL/include/SSDL_font.h
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <SDL_ttf.h>
+#include <string>
 
 //Because TTF_Font* must be destructed by TTF_CloseFont... and because shared_ptr
 // instead calls a dtor... and TTF_Font won't allow inheritance from it...


### PR DESCRIPTION
Missing <string> header for std::string